### PR TITLE
resolve #44 サイドバー：お知らせコンポーネント実装

### DIFF
--- a/src/components/pages/top/presenter.tsx
+++ b/src/components/pages/top/presenter.tsx
@@ -16,6 +16,7 @@ import Footer from './footer';
 import Header from './header';
 import Scene from './scene';
 import SidebarCount from './sidebarCount';
+import SidebarNotice from './sidebarNotice';
 import SidebarUserInfo from './sidebarUserInfo';
 import SpecialFeature from './specialFeature';
 import {
@@ -51,6 +52,7 @@ const Presenter = () => {
           <StyledSidebarColumn>
             <SidebarCount />
             <SidebarUserInfo />
+            <SidebarNotice />
           </StyledSidebarColumn>
         </StyledMainContents>
       </StyledMainContainer>

--- a/src/components/pages/top/sidebarNotice/index.tsx
+++ b/src/components/pages/top/sidebarNotice/index.tsx
@@ -1,0 +1,6 @@
+import Presenter from './presenter';
+
+/** サイドバー：食べログからのお知らせ */
+const SidebarNotice = () => <Presenter />;
+
+export default SidebarNotice;

--- a/src/components/pages/top/sidebarNotice/presenter.tsx
+++ b/src/components/pages/top/sidebarNotice/presenter.tsx
@@ -1,0 +1,40 @@
+import H2Component from '../../../uiParts/h2Component';
+
+import {
+  StyledNoticeDateSpan,
+  StyledNoticeLink,
+  StyledNoticeList,
+  StyledNoticeSpan,
+} from './style';
+
+const Presenter = () => (
+  <div css="width: 100%">
+    <div css="margin-top: 40px;">
+      <H2Component>食べログからのお知らせ</H2Component>
+      <ul>
+        <StyledNoticeList>
+          <StyledNoticeSpan>お知らせ</StyledNoticeSpan>
+          <StyledNoticeDateSpan>2022.02.07</StyledNoticeDateSpan>
+          <StyledNoticeLink href="/">利用規約改定のお知らせ</StyledNoticeLink>
+        </StyledNoticeList>
+        <StyledNoticeList>
+          <StyledNoticeSpan>お知らせ</StyledNoticeSpan>
+          <StyledNoticeDateSpan>2022.01.13</StyledNoticeDateSpan>
+          <StyledNoticeLink href="/">
+            Go To
+            Eatキャンペーンで付与されたポイントのご利用について（2022/1/13更新）
+          </StyledNoticeLink>
+        </StyledNoticeList>
+        <StyledNoticeList>
+          <StyledNoticeSpan>お知らせ</StyledNoticeSpan>
+          <StyledNoticeDateSpan>2020.11.09</StyledNoticeDateSpan>
+          <StyledNoticeLink href="/">
+            新型コロナウイルス拡大における対応のお願い（2022/1/20更新）
+          </StyledNoticeLink>
+        </StyledNoticeList>
+      </ul>
+    </div>
+  </div>
+);
+
+export default Presenter;

--- a/src/components/pages/top/sidebarNotice/style.ts
+++ b/src/components/pages/top/sidebarNotice/style.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components/macro';
+
+export const StyledNoticeList = styled.li`
+  padding: 14px 0;
+  border-bottom: 1px solid #e9e9e9;
+`;
+
+export const StyledNoticeSpan = styled.span`
+  display: inline-block;
+  min-width: 48px;
+  padding: 3px 3px 2px;
+  margin: 0;
+  font-size: 10px;
+  font-weight: normal;
+  line-height: 1.2;
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  background-color: #bcb08a;
+  border-radius: 2px;
+`;
+
+export const StyledNoticeDateSpan = styled.span`
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #13131e;
+  vertical-align: middle;
+`;
+
+export const StyledNoticeLink = styled.a`
+  display: block;
+  margin-top: 5px;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.5;
+
+  &:hover {
+    color: #ff9600;
+    text-decoration: underline;
+  }
+`;


### PR DESCRIPTION
## What
- サイドバー：お知らせコンポーネント実装

## Why
- 食べログからのお知らせにアクセスしやすいようにサイドバーに実装